### PR TITLE
Improve robustness

### DIFF
--- a/oshino/agents/test_agent.py
+++ b/oshino/agents/test_agent.py
@@ -1,3 +1,5 @@
+import asyncio
+
 from . import Agent
 
 
@@ -9,4 +11,20 @@ class StubAgent(Agent):
     async def process(self, event_fn):
         event_fn(metric_f=1.0,
                  service="test",
+                 tags=["test"])
+
+
+class LaggingAgent(Agent):
+
+    def __init__(self, cfg, lag):
+        super(LaggingAgent, self).__init__(cfg)
+        self.lag = lag
+
+    def is_valid(self):
+        return True
+
+    async def process(self, event_fn):
+        await asyncio.sleep(self.lag)
+        event_fn(metric_f=1.0,
+                 service="lagging_test",
                  tags=["test"])

--- a/oshino/core/__init__.py
+++ b/oshino/core/__init__.py
@@ -25,3 +25,11 @@ def send_metrics_count(event_fn, logger, count):
     event_fn(metric_f=count,
              service="oshino.metrics_count",
              tags=["oshino", "instrumentation"])
+
+
+def send_pending_events_count(event_fn, logger, count):
+    logger.debug("There are {0} events which are still being processed"
+                 .format(count))
+    event_fn(metric_f=count,
+             service="oshino.pending_events_count",
+             tags=["oshino", "instrumentation"])

--- a/oshino/core/heart.py
+++ b/oshino/core/heart.py
@@ -18,6 +18,7 @@ from . import (send_heartbeat,
                send_timedelta,
                send_pending_events_count,
                send_metrics_count)
+from . import processor
 
 
 T = TypeVar("T")
@@ -30,14 +31,6 @@ def create_loop():
 def forever():
     return True
 
-
-def flush_riemann(client, transport, logger):
-    try:
-        transport.connect()
-        client.flush()
-        transport.disconnect()
-    except ConnectionRefusedError as ce:
-        logger.warn(ce)
 
 
 def create_agents(agents_cfg: list):
@@ -111,7 +104,7 @@ async def main_loop(cfg: Config,
                         len(client.queue.events),
                         len(pending))
 
-        flush_riemann(client, transport, logger)
+        processor.flush(client, transport, logger)
         if continue_fn():
             await asyncio.sleep(cfg.interval - int(td), loop=loop)
         else:

--- a/oshino/core/heart.py
+++ b/oshino/core/heart.py
@@ -63,7 +63,7 @@ async def step(client: object, agents: list, timeout: int, loop: BaseEventLoop):
     return await asyncio.wait(tasks, timeout=timeout)
 
 
-def instrumentation(client: QueuedClient,
+def instrumentation(client: processor.QClient,
                     logger: Logger,
                     interval: int,
                     delta: int,

--- a/oshino/core/heart.py
+++ b/oshino/core/heart.py
@@ -31,7 +31,6 @@ def forever():
     return True
 
 
-
 def create_agents(agents_cfg: list):
     return list(map(lambda x: (x.instance, x), agents_cfg))
 
@@ -41,7 +40,10 @@ def init(agents: list):
         agent.on_start()
 
 
-async def step(client: object, agents: list, timeout: int, loop: BaseEventLoop):
+async def step(client: object,
+               agents: list,
+               timeout: int,
+               loop: BaseEventLoop):
     tasks = []
 
     for agent, agent_cfg in agents:

--- a/oshino/core/heart.py
+++ b/oshino/core/heart.py
@@ -7,7 +7,6 @@ from typing import TypeVar, Generic
 from asyncio import BaseEventLoop
 
 from logbook import Logger, StreamHandler
-from riemann_client.client import QueuedClient
 from raven.handlers.logbook import SentryHandler
 from raven import Client as SentryClient
 from logbook import NestedSetup
@@ -83,7 +82,7 @@ async def main_loop(cfg: Config,
                     loop: BaseEventLoop):
     riemann = cfg.riemann
     transport = transport_cls(riemann.host, riemann.port)
-    client = QueuedClient(transport)
+    client = processor.QClient(transport)
     agents = create_agents(cfg.agents)
 
     init(agents)

--- a/oshino/core/processor.py
+++ b/oshino/core/processor.py
@@ -1,0 +1,7 @@
+def flush(client, transport, logger):
+    try:
+        transport.connect()
+        client.flush()
+        transport.disconnect()
+    except ConnectionRefusedError as ce:
+        logger.warn(ce)

--- a/oshino/core/processor.py
+++ b/oshino/core/processor.py
@@ -2,7 +2,16 @@ from riemann_client.client import QueuedClient
 
 
 class QClient(QueuedClient):
-    pass
+    def __init__(self, *args, **kwargs):
+        super(QClient, self).__init__(*args, **kwargs)
+        self.augments = []
+
+    def event(self, **data):
+        if data['service'] in self.augments:
+            subscribers = self.augments[data["service"]]
+            for sub in subscribers:
+                sub.send(**data)
+        super(QClient, self).event(**data)
 
 
 def flush(client, transport, logger):
@@ -12,3 +21,7 @@ def flush(client, transport, logger):
         transport.disconnect()
     except ConnectionRefusedError as ce:
         logger.warn(ce)
+
+
+def register_augment(client, key, generator, logger):
+    pass

--- a/oshino/core/processor.py
+++ b/oshino/core/processor.py
@@ -1,3 +1,10 @@
+from riemann_client.client import QueuedClient
+
+
+class QClient(QueuedClient):
+    pass
+
+
 def flush(client, transport, logger):
     try:
         transport.connect()

--- a/oshino/version.py
+++ b/oshino/version.py
@@ -3,7 +3,7 @@ Module just to print out current version.
 That's all.
 """
 
-VERSION = (0, 1, "9")
+VERSION = (0, 2, "0")
 
 
 def get_version():

--- a/tests/mocks.py
+++ b/tests/mocks.py
@@ -1,13 +1,17 @@
 from riemann_client.transport import BlankTransport
 
+from oshino.core.processor import AugmentFixture
 
-class MockClient(object):
+
+class MockClient(AugmentFixture):
 
     def __init__(self):
         self.events = []
+        self.augments = {}
 
-    def event(self, *args, **kwargs):
-        self.events.append((args, kwargs))
+    def event(self, **kwargs):
+        self.apply_augment(**kwargs)
+        self.events.append(kwargs)
 
     def flush(self):
         self.events = []

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -144,3 +144,7 @@ class TestRobustness(object):
         assert len(mock_client.events) == 1
         assert len(done) == 1
         assert len(pending) == 1
+
+        # Wait for our slow guy to finish
+        for p in pending:
+            await p

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -124,6 +124,7 @@ class TestHeart(object):
 
 class TestRobustness(object):
 
+    @mark.slow
     @mark.asyncio
     async def test_w_lagging_agent(self,
                                    stub_agent,

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -92,8 +92,8 @@ class TestHeart(object):
         assert len(mock_client.events) == 1
 
     def test_instrumentation(self, mock_client):
-        instrumentation(mock_client, logger, 0, 0, 0)
-        assert len(mock_client.events) == 3
+        instrumentation(mock_client, logger, 0, 0, 0, 0)
+        assert len(mock_client.events) == 4
 
     def test_flush(self, mock_client, mock_transport):
         assert len(mock_client.events) == 0

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -8,11 +8,11 @@ from oshino.core import send_heartbeat, send_timedelta, send_metrics_count
 from oshino.config import AgentConfig, Config
 from oshino.core.heart import (step,
                                instrumentation,
-                               flush_riemann,
                                create_agents,
                                init,
                                forever,
                                create_loop)
+from oshino.core import processor
 from oshino.agents.test_agent import StubAgent, LaggingAgent
 from .fixtures import mock_transport, mock_client, broken_transport
 
@@ -99,12 +99,12 @@ class TestHeart(object):
         assert len(mock_client.events) == 0
         mock_client.event()
         assert len(mock_client.events) == 1
-        flush_riemann(mock_client, mock_transport, logger)
+        processor.flush(mock_client, mock_transport, logger)
         assert len(mock_client.events) == 0
         assert not mock_transport.connected
 
     def test_flush_w_error(self, mock_client, broken_transport):
-        flush_riemann(mock_client, broken_transport, logger)
+        processor.flush(mock_client, broken_transport, logger)
 
     def test_agents_creation(self, base_config):
         result = create_agents(base_config.agents)


### PR DESCRIPTION
Main features:
* If agent is too slow to push event, oshino will skip it for current iteration. One bad agent will not bring down whole system with him. However, it can make all events slower due to timeout
* Added possibility (but no actual documentation, config or interface yet) to add event augmentation - taking selected events and generating new ones